### PR TITLE
Add exception handling in web api

### DIFF
--- a/src/KITT.Core/KITT.Core.csproj
+++ b/src/KITT.Core/KITT.Core.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.4.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
+    <PackageReference Include="FluentValidation" Version="11.0.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/KITT.Web.App.Tools/KITT.Web.App.Tools.csproj
+++ b/src/KITT.Web.App.Tools/KITT.Web.App.Tools.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.4" />
+	<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KITT.Web.App.UI/KITT.Web.App.UI.csproj
+++ b/src/KITT.Web.App.UI/KITT.Web.App.UI.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.4" />
-    <PackageReference Include="MudBlazor" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.5" />
+    <PackageReference Include="MudBlazor" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KITT.Web.App/KITT.Web.App.csproj
+++ b/src/KITT.Web.App/KITT.Web.App.csproj
@@ -7,13 +7,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.4" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="6.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.5" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="6.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.4" />
-		<PackageReference Include="MudBlazor" Version="6.0.9" />
-		<PackageReference Include="MudBlazor.Markdown" Version="0.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.5" />
+		<PackageReference Include="MudBlazor" Version="6.0.10" />
+		<PackageReference Include="MudBlazor.Markdown" Version="0.0.10" />
 		<PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
 	</ItemGroup>
 

--- a/src/LemonBot.Commands/LemonBot.Commands.csproj
+++ b/src/LemonBot.Commands/LemonBot.Commands.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/LemonBot.Web/Extensions/WebApplicationExtensions.cs
+++ b/src/LemonBot.Web/Extensions/WebApplicationExtensions.cs
@@ -1,4 +1,5 @@
-﻿using LemonBot.Web.GraphQL;
+﻿using Hellang.Middleware.ProblemDetails;
+using LemonBot.Web.GraphQL;
 using LemonBot.Web.Hubs;
 
 namespace LemonBot.Web.Extensions;
@@ -15,7 +16,6 @@ public static class WebApplicationExtensions
         }
         else
         {
-            app.UseExceptionHandler("/Home/Error");
             // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
             app.UseHsts();
         }
@@ -23,6 +23,8 @@ public static class WebApplicationExtensions
         app.UseHttpsRedirection();
         app.UseBlazorFrameworkFiles();
         app.UseStaticFiles();
+
+        app.UseProblemDetails();
 
         app.UseRouting();
 

--- a/src/LemonBot.Web/LemonBot.Web.csproj
+++ b/src/LemonBot.Web/LemonBot.Web.csproj
@@ -18,18 +18,18 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="12.8.0" />
-    <PackageReference Include="HotChocolate.Data" Version="12.8.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.9.0" />
+    <PackageReference Include="HotChocolate.Data" Version="12.9.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.4">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.23.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.24.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LemonBot.Web/LemonBot.Web.csproj
+++ b/src/LemonBot.Web/LemonBot.Web.csproj
@@ -18,6 +18,7 @@
 	</ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.4.2" />
     <PackageReference Include="HotChocolate.AspNetCore" Version="12.9.0" />
     <PackageReference Include="HotChocolate.Data" Version="12.9.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />

--- a/src/LemonBot/LemonBot.csproj
+++ b/src/LemonBot/LemonBot.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.3" />
+    <PackageReference Include="System.Text.Json" Version="6.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LemonBot.Commands\LemonBot.Commands.csproj" />

--- a/tests/KITT.Core.Test/KITT.Core.Test.csproj
+++ b/tests/KITT.Core.Test/KITT.Core.Test.csproj
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/KITT.Web.App.Test/KITT.Web.App.Test.csproj
+++ b/tests/KITT.Web.App.Test/KITT.Web.App.Test.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.6.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="bunit" Version="1.7.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/LemonBot.Web.Test.Integration/Console/StreamingsControllerTest.cs
+++ b/tests/LemonBot.Web.Test.Integration/Console/StreamingsControllerTest.cs
@@ -70,7 +70,7 @@ public class StreamingsControllerTest :
         Assert.NotNull(model);
         Assert.Equal(
             new StreamingsListModel.StreamingListItemModel { Id = createdStreamingId, EndingTime = scheduleDate.AddHours(18), StartingTime = scheduleDate.AddHours(16), HostingChannelUrl = "albx87", ScheduledOn = scheduleDate, Title = "test" },
-            model.Items.First());
+            model!.Items.First());
     }
     #endregion
 
@@ -199,6 +199,72 @@ public class StreamingsControllerTest :
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal(model, modelFromResponse);
     }
+
+    [Fact]
+    public async Task ScheduleStreaming_Should_Return_Bad_Request_If_Schedule_Date_Is_Previous_Than_Today()
+    {
+        var scheduleDate = DateTime.Today.AddDays(-1);
+        var startingTime = TimeSpan.FromHours(16);
+        var endingTime = TimeSpan.FromHours(18);
+        var userId = TestAuthenticationHandler.UserId;
+
+        var client = this.factory
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddTestAuthentication();
+                });
+            })
+            .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var model = new ScheduleStreamingModel
+        {
+            EndingTime = scheduleDate.Add(endingTime),
+            HostingChannelUrl = "https://www.twitch.tv/albx87",
+            ScheduleDate = scheduleDate,
+            Slug = "test-create",
+            StartingTime = scheduleDate.Add(startingTime),
+            StreamingAbstract = "test",
+            Title = "test create"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/console/streamings", model);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ScheduleStreaming_Should_Return_Bad_Request_If_Ending_Time_Is_Previous_Than_Starting_Time()
+    {
+        var scheduleDate = DateTime.Today.AddDays(1);
+        var startingTime = TimeSpan.FromHours(18);
+        var endingTime = TimeSpan.FromHours(16);
+        var userId = TestAuthenticationHandler.UserId;
+
+        var client = this.factory
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddTestAuthentication();
+                });
+            })
+            .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var model = new ScheduleStreamingModel
+        {
+            EndingTime = scheduleDate.Add(endingTime),
+            HostingChannelUrl = "https://www.twitch.tv/albx87",
+            ScheduleDate = scheduleDate,
+            Slug = "test-create",
+            StartingTime = scheduleDate.Add(startingTime),
+            StreamingAbstract = "test",
+            Title = "test create"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/console/streamings", model);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
     #endregion
 
     #region ImportStreaming tests
@@ -256,6 +322,40 @@ public class StreamingsControllerTest :
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal(model, modelFromResponse);
+    }
+
+    [Fact]
+    public async Task ImportStreaming_Should_Return_Bad_Request_If_Ending_Time_Is_Previous_Than_Starting_Time()
+    {
+        var scheduleDate = DateTime.Today.AddDays(-1);
+        var startingTime = TimeSpan.FromHours(18);
+        var endingTime = TimeSpan.FromHours(16);
+        var userId = TestAuthenticationHandler.UserId;
+
+        var client = this.factory
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddTestAuthentication();
+                });
+            })
+            .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var model = new ImportStreamingModel
+        {
+            EndingTime = scheduleDate.Add(endingTime),
+            HostingChannelUrl = "https://www.twitch.tv/albx87",
+            ScheduleDate = scheduleDate,
+            Slug = "test-import",
+            StartingTime = scheduleDate.Add(startingTime),
+            StreamingAbstract = "test",
+            Title = "test import",
+            YoutubeVideoUrl = "youtube.com/test"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/console/streamings/import", model);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
     #endregion
 

--- a/tests/LemonBot.Web.Test.Integration/LemonBot.Web.Test.Integration.csproj
+++ b/tests/LemonBot.Web.Test.Integration/LemonBot.Web.Test.Integration.csproj
@@ -9,12 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="Moq" Version="4.17.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Moq" Version="4.18.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
Fixes issue #45 

- Update NuGet packages
- Added ProblemDetails middleware to explicitly map exceptions to HTTP status codes
- Added some integration tests