### PR TITLE
Bump OpenTelemetry.Exporter.OpenTelemetryProtocol to 1.15.3

### DIFF
--- a/src/KITT.ServiceDefaults/KITT.ServiceDefaults.csproj
+++ b/src/KITT.ServiceDefaults/KITT.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/KITT.ServiceDefaults/KITT.ServiceDefaults.csproj
+++ b/src/KITT.ServiceDefaults/KITT.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />


### PR DESCRIPTION
This pull request makes a minor update to the `KITT.ServiceDefaults` project by bumping the version of the `OpenTelemetry.Exporter.OpenTelemetryProtocol` package from 1.15.1 to 1.15.3, which may include bug fixes or minor improvements.

- Upgraded `OpenTelemetry.Exporter.OpenTelemetryProtocol` NuGet package to version 1.15.3 in `KITT.ServiceDefaults.csproj` for improved stability and compatibility.